### PR TITLE
rework to support multiple concurrent instances

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ The first time you install this app, before using a cron job, you properly want 
 	</description>
 	<licence>AGPL</licence>
 	<author>Roeland Jago Douma</author>
-	<version>2.1.0</version>
+	<version>2.2.0</version>
 	<namespace>PreviewGenerator</namespace>
 	<category>multimedia</category>
 	<website>https://github.com/rullzer/previewgenerator</website>

--- a/composer/composer/autoload_classmap.php
+++ b/composer/composer/autoload_classmap.php
@@ -12,6 +12,7 @@ return array(
     'OCA\\PreviewGenerator\\Command\\PreGenerate' => $baseDir . '/../lib/Command/PreGenerate.php',
     'OCA\\PreviewGenerator\\Command\\TimestampFormatter' => $baseDir . '/../lib/Command/TimestampFormatter.php',
     'OCA\\PreviewGenerator\\Migration\\Version020000Date20180823071939' => $baseDir . '/../lib/Migration/Version020000Date20180823071939.php',
+    'OCA\\PreviewGenerator\\Migration\\Version020200Date20190608205303' => $baseDir . '/../lib/Migration/Version020200Date20190608205303.php',
     'OCA\\PreviewGenerator\\SizeHelper' => $baseDir . '/../lib/SizeHelper.php',
     'OCA\\PreviewGenerator\\Watcher' => $baseDir . '/../lib/Watcher.php',
 );

--- a/composer/composer/autoload_static.php
+++ b/composer/composer/autoload_static.php
@@ -27,6 +27,7 @@ class ComposerStaticInitPreviewGenerator
         'OCA\\PreviewGenerator\\Command\\PreGenerate' => __DIR__ . '/..' . '/../lib/Command/PreGenerate.php',
         'OCA\\PreviewGenerator\\Command\\TimestampFormatter' => __DIR__ . '/..' . '/../lib/Command/TimestampFormatter.php',
         'OCA\\PreviewGenerator\\Migration\\Version020000Date20180823071939' => __DIR__ . '/..' . '/../lib/Migration/Version020000Date20180823071939.php',
+        'OCA\\PreviewGenerator\\Migration\\Version020200Date20190608205303' => __DIR__ . '/..' . '/../lib/Migration/Version020200Date20190608205303.php',
         'OCA\\PreviewGenerator\\SizeHelper' => __DIR__ . '/..' . '/../lib/SizeHelper.php',
         'OCA\\PreviewGenerator\\Watcher' => __DIR__ . '/..' . '/../lib/Watcher.php',
     );

--- a/lib/Migration/Version020200Date20190608205303.php
+++ b/lib/Migration/Version020200Date20190608205303.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyleft (c) 2019, Ignacio Nunez <nacho@ownyourbits.com>
+ *
+ * @author Ignacio Nunez <nacho@ownyourbits.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\PreviewGenerator\Migration;
+
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+use Doctrine\DBAL\Types\Type;
+
+class Version020200Date20190608205303 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$table = $schema->getTable('preview_generation');
+
+		if (!$table->hasColumn('locked')) {
+			$table->addColumn('locked', Type::BOOLEAN, [
+				'notnull' => true,
+				'default' => 0,
+			]);
+		}
+		return $schema;
+	}
+}


### PR DESCRIPTION
### Motivation and goals

See https://github.com/nachoparker/server/pull/1

### Changes

This PR is a PoC which allows multiple concurrent executions of the preview generator in order to speed up the process by using more cores.

Ideally we would use a PHP native method for creating theads but this does not have good distribution support yet (see next section).

### Results

See https://github.com/nachoparker/server/pull/1 for details

| Method          | Processes | Threads | Interpolate | JPEG quality | Time | % of initial |
|-----------------|-----------|---------|-------------|--------------|------|--------------|
| GD  | 1         | 1       | yes         | 60           | 1m50 | -            |
| GD  | 4         | 1       | yes         | 60           | 28s  | 25%          |
| Imagick         | 4         | 1       | no          | 90           | 23s  | 20%          |
| Imagick         | 4         | 1       | no          | 60           | 22s  | 20%          |
| GD  | 16        | 1       | yes         | 60           | 12s  | 11%          |
| Imagick         | 16        | 1       | no          | 90           | 10s  | 9%           |
| Imagick         | 16        | 1       | no          | 60           | 10s  | 9%           |

### Future work

- Study generating the images in the upload hook with multiple threads so we don't need the preview generator cron job.
- Modify Preview Generator to spawn multiple threads using `pthreads` or `parallel` once there are ZTS PHP packages available ([link](https://github.com/oerdnj/deb.sury.org/issues/327) [link](https://github.com/oerdnj/deb.sury.org/issues/491)) instead of relying on an external script that launches several processes in parallel.

Signed-off-by: nachoparker <nacho@ownyourbits.com>